### PR TITLE
Cleanup spec

### DIFF
--- a/sgd/sgd-aa-oas3.yml
+++ b/sgd/sgd-aa-oas3.yml
@@ -39,8 +39,8 @@ paths:
     get:
       operationId: show_status
       description: |-
-        This path can be used to health-check the API. 
-        Using this path prevents arbitrary use of a server URL 
+        This path can be used to health-check the API.
+        Using this path prevents arbitrary use of a server URL
         for the scope of the health check.
       summary: >-
         Verifies that the server is working correctly.
@@ -61,9 +61,9 @@ paths:
       operationId: list_versions
       summary: Returns the list of all available versions of the API
       description: |-
-        It provides a chronological list of all the available API versions. 
-        Each item of the list contains the version number 
-        together with the released date of the API. 
+        It provides a chronological list of all the available API versions.
+        Each item of the list contains the version number
+        together with the released date of the API.
       responses:
         <<: *common-responses
         "200":
@@ -164,14 +164,14 @@ paths:
       summary: Returns the list of the delegations
       description: |-
         List of the delegations related to the services
-        (or class of services) provided by the authenticated RP and having 
-        the current user as delegator. 
-         
-        For privacy reason, each item contains 
-        only the minimum set of information about the delegations, 
+        (or class of services) provided by the authenticated RP and having
+        the current user as delegator.
+
+        For privacy reason, each item contains
+        only the minimum set of information about the delegations,
         needed by the user to select the delegation he wants to use.
-        Only *the delegation identification number* and the *delegator 
-        fiscal number partially hidden* is given. 
+        Only *the delegation identification number* and the *delegator
+        fiscal number partially hidden* is given.
 
         FIXME: da dove è recuperata l'informazione dell'utente?
 
@@ -203,7 +203,7 @@ paths:
     get:
       operationId: show_delegation
       summary: >-
-        Returns the attributes related to a given delegation 
+        Returns the attributes related to a given delegation
       description: |-
         Returns the full set of attributes related to a selected delegation
         identified by the delegation_id component of the URL
@@ -318,7 +318,7 @@ components:
       description: |-
         Internal server error.
 
-        FIXME: a differenza di 503, 
+        FIXME: a differenza di 503,
                questa risposta di solito non fa parte del contratto ;)
                si può usare `default`
       x-noqa: Risposta OAuth2
@@ -401,7 +401,7 @@ components:
       description: |-
         JSON Object containing the delegation list.
 
-        FIXME: valutare delle properties di contorno 
+        FIXME: valutare delle properties di contorno
                utili anche alla paginazione (count, limit, next, ...)
       properties:
         items:
@@ -498,7 +498,7 @@ components:
               default: https://deleghedigitali.gov.it/
               example: "https://deleghedigitali.gov.it/"
             sub:
-              title: Delegate User Identifier. 
+              title: Delegate User Identifier.
               <<: *TIN
             id:
               type: string

--- a/sgd/sgd-aa-oas3.yml
+++ b/sgd/sgd-aa-oas3.yml
@@ -18,136 +18,141 @@ info:
   x-summary: A subtitle for the catalog
 servers:
   - url: https://deleghedigitali.gov.it/api/v1
-
+    description: Produzione.
+x-commons:
+  common-responses: &common-responses
+   default:
+     $ref: "#/components/responses/default"
+  full-responses: &full-responses
+    "400":
+      $ref: "#/components/responses/400"
+    "401":
+      $ref: "#/components/responses/401"
+    "404":
+      $ref: "#/components/responses/404"
+    "429":
+      $ref: "#/components/responses/429"
+    "500":
+      $ref: "#/components/responses/500"
 paths:
   /status:
     get:
-      operationId: get-status
-      description: This path can be used to health-check the API. Using this path prevents arbitrary use of a server URL for the scope of the health check.
-      summary: Returns a response containing a successful status code if the service is working correctly.
+      operationId: show_status
+      description: |-
+        This path can be used to health-check the API. 
+        Using this path prevents arbitrary use of a server URL 
+        for the scope of the health check.
+      summary: >-
+        Verifies that the server is working correctly.
       responses:
+        <<: *common-responses
         "200":
-          description: ok
+          description: |-
+            The server is working correctly.
           content:
-            application/json:
+            application/problem+json:
               schema:
-                type: string
+                $ref: "#/components/schemas/Problem"
       tags:
         - public
-  /versioning:
+  /docs/versions:
     #TODO: Maybe a pagination could be useful for this path
     get:
-      operationId: get-versioning
+      operationId: list_versions
       summary: Returns the list of all available versions of the API
-      description: It provides a chronological list of all the available API versions. Each item of the list contains the version number together with the released date of the API.
+      description: |-
+        It provides a chronological list of all the available API versions. 
+        Each item of the list contains the version number 
+        together with the released date of the API. 
       responses:
+        <<: *common-responses
         "200":
           description: Ok
           content:
             text/html:
               schema:
-                type: string
+                $ref: '#/components/schemas/HTMLDocument'
             application/json:
               schema:
-                type: object
-                description:
-                  "JSON Object containing the list of all available versions of
-                  this API."
-                properties:
-                  versions_list:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        iat:
-                          type: integer
-                          minimum: 0
-                          exclusiveMinimum: true
-                          description:
-                            UNIX timestamp of when this version was released
-                        version:
-                          type: string
-                          description:
-                            Version identifier of API given in the format
-                            'v<MAJOR.MINOR.PATCH>'
-                      required:
-                        - iat
-                        - version
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/APIVersions'
       tags:
         - public
+        - documentation
+        - guidelines
       x-spid-operation: # See §2.8
         consentRequired: "N"
         offlineAccess: true
         offlineAccessDurationMax: 8640000
-  /latest:
+  /docs/versions/latest:
     get:
-      operationId: get-latest
+      operationId: list_latest
       summary: Returns the document describing the latest version of the API
+      description: |-
+        Returns the document describing the latest version of the API
+
+        FIXME: è un redirect, probabilmente non ritorna un documento.
       responses:
+        <<: *common-responses
         "302":
-          description: Ok
+          description: |-
+            A redirect URL where the latest version is located
+                ('https://deleghedigitali.gov.it/api/v<LATEST_VERSION>')
           headers:
-            location:
+            Location:
               schema:
                 type: string
-              description:
-                URL where the latest version is located
-                ('https://deleghedigitali.gov.it/api/v<LATEST_VERSION>')
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                format: url
+              description: |-
+                The url of an API version.
       tags:
         - public
+        - documentation
+        - guidelines
       x-spid-operation: # See §2.8
         consentRequired: "N"
         offlineAccess: true
         offlineAccessDurationMax: 8640000
-  /v1:
+  /docs/versions/v1:
     get:
-      operationId: get-version
+      operationId: show_version
       summary: Returns the document describing this version of the API.
+      description: |-
+        FIXME: questo espone https://.../api/v1/v1. E' quello che si vuole?
       responses:
+        <<: *common-responses
         "200":
           description: Ok
           content:
             text/html:
               schema:
-                type: string
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
+                $ref: '#/components/schemas/HTMLDocument'
       tags:
         - public
+        - documentation
       x-spid-operation: # See §2.8
         consentRequired: "N"
         offlineAccess: true
         offlineAccessDurationMax: 8640000
 
-  /tos:
+  /docs/tos:
     get:
       description: It provides an HTML page with the Terms of Service
-      operationId: get-tos
+      operationId: show_tos
       summary:
         Returns the document with the terms and conditions related to this
         system
       responses:
+        <<: *common-responses
         "200":
           description: Ok
           content:
             text/html:
               schema:
-                type: string
-                description: HTML page with the Terms of Service
-        "404":
-          $ref: "#/components/responses/404"
+                $ref: '#/components/schemas/HTMLDocument'
       tags:
         - public
+        - guidelines
+        - documentation
       x-spid-operation: # See §2.8
         consentRequired: "N"
         offlineAccess: true
@@ -155,52 +160,23 @@ paths:
 
   /delegations:
     get:
-      operationId: get-delegation
+      operationId: list_delegations
       summary: Returns the list of the delegations
-      description: It provides the list of the delegations related to the services (or class of services) provided by the authenticated RP and having the current user as delegator. For privacy reason, each item contains only the minimum set of information about the delegations, needed by the user to select the delegation he wants to use. Only the delegation identification number and the delegator fiscal number partially hidden is given.
-      security:
-        - dpopToken: []
-          dpopProof: []
-      parameters:
-        - name: DPoP
-          in: header
-          required: true
-          description: DPoP proof
-          schema:
-            "$ref": "#/components/schemas/DPoP"
-      x-spid-operation: # See §2.8
-        consentRequired: "SP"
-        spidLevel: SPID2
-        offlineAccess: false
-        offlineAccessDurationMax: 0
-      tags:
-        - protected
-      responses:
-        "200":
-          description: Ok
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Delegations"
-              examples:
-                delegations:
-                  $ref: "#/components/examples/delegations"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-          #The requested service (or class of services) does not exist
-        "429":
-          $ref: "#/components/responses/429"
-        "500":
-          $ref: "#/components/responses/500"
+      description: |-
+        List of the delegations related to the services
+        (or class of services) provided by the authenticated RP and having 
+        the current user as delegator. 
+         
+        For privacy reason, each item contains 
+        only the minimum set of information about the delegations, 
+        needed by the user to select the delegation he wants to use.
+        Only *the delegation identification number* and the *delegator 
+        fiscal number partially hidden* is given. 
 
-  /delegations/{services}:
-    get:
-      description: "It provides the list of the delegations having the current user as  delegator and related to the services (or class of services) provided by the authenticated RP and identifed from the service component in the URL. For privacy reason, each item contains only the minimum set of information about the delegations, needed by the user to select the delegation he wants to use. Only the delegation identification number and the delegator fiscal number partially hidden is given. "
-      operationId: list-delegation-for-service
-      summary:
-        "Returns the list of the delegations given the services (or class of services) identifiers as input"
+        FIXME: da dove è recuperata l'informazione dell'utente?
+
+      parameters:
+        - $ref: "#/components/parameters/service_id"
       security:
         - dpopToken: []
           dpopProof: []
@@ -211,19 +187,9 @@ paths:
         offlineAccessDurationMax: 0
       tags:
         - protected
-      parameters:
-        - in: query
-          name: service
-          required: false
-          schema:
-            type: string
-            format: uuid
-          description:
-            Identifier of the service (or class of services) as given in the
-            online OAS3 catalog of delegable services provided by the
-            authenticated RP. It must be a UUID v4 identifier.
-          example: 21905575-991a-43d5-bede-25f59ae93373
+        - guidelines
       responses:
+        <<: *full-responses
         "200":
           description: Ok
           content:
@@ -231,24 +197,17 @@ paths:
               schema:
                 $ref: "#/components/schemas/Delegations"
               examples:
-                delegations_services:
-                  $ref: "#/components/examples/delegations_services"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "429":
-          $ref: "#/components/responses/429"
-        "500":
-          $ref: "#/components/responses/500"
-
+                Delegations:
+                  $ref: "#/components/examples/Delegations"
   /delegations/{id}:
     get:
-      operationId: get-delegation-id
-      summary: "Returns the attributes related to the delegation identified by the delegation_id component of the URL"
-      description: "It provides the full set of attributes related to a selected delegation as a signed JWT object"
+      operationId: show_delegation
+      summary: >-
+        Returns the attributes related to a given delegation 
+      description: |-
+        Returns the full set of attributes related to a selected delegation
+        identified by the delegation_id component of the URL
+        as a signed JWT object.
       security:
         - dpopToken: []
           dpopProof: []
@@ -259,33 +218,27 @@ paths:
         offlineAccessDurationMax: 0
       tags:
         - protected
+        - guidelines
       parameters:
         - in: path
           name: id
           required: true
-          schema:
-            type: string
           description: Identitier of this delegation as defined by SGD
+          schema:
+            $ref: '#/components/schemas/DelegationId'
       responses:
+        <<: *full-responses
         "200":
-          description: Ok
+          description: |-
+            A set of delegation attributes in a JWS.
           content:
             application/jwt:
               schema:
                 $ref: "#/components/schemas/DelegationAttribute"
               examples:
-                delegations_attributes:
-                  $ref: "#/components/examples/delegations_attributes"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "429":
-          $ref: "#/components/responses/429"
-        "500":
-          $ref: "#/components/responses/500"
+                DelegationAttributes:
+                  $ref: "#/components/examples/DelegationAttributes"
+
 
 components:
   securitySchemes:
@@ -294,7 +247,8 @@ components:
       scheme: DPoP
     dpopProof:
       description: |-
-        Una DPoP proof basata su https://github.com/danielfett/draft-dpop/blob/master/main.md
+        Una DPoP proof basata su
+         https://github.com/danielfett/draft-dpop/blob/master/main.md
       type: apiKey
       in: header
       name: DPoP
@@ -306,8 +260,15 @@ components:
         "DPoP-bound Access Token releases by the STS endpoint of SGD during the
         Token Exchange OAuth2 protocol"
   responses:
+    default:
+      $ref: 'https://teamdigitale.github.io/openapi/v0.1.0/definitions.yaml#/components/responses/default'
+
     "400":
-      description: Bad request.
+      description: |-
+        Bad request.
+
+        FIXME: definire response diverse per OAuth e API.
+      x-noqa: Risposta OAuth2
       content:
         application/json:
           schema:
@@ -321,6 +282,7 @@ components:
       description:
         The client request has not been completed because it lacks valid
         authorization credentials for the requested resource.
+      x-noqa: Risposta OAuth2
       content:
         application/json:
           schema:
@@ -332,6 +294,7 @@ components:
               authorization credentials for the requested resource.
     "404":
       description: The requested resource was not found
+      x-noqa: Risposta OAuth2
       content:
         application/json:
           schema:
@@ -341,6 +304,7 @@ components:
             error_description: The requested resource was not found
     "429":
       description: Too Many Requests
+      x-noqa: Risposta OAuth2
       content:
         application/json:
           schema:
@@ -351,7 +315,13 @@ components:
               The rate limit was exceeded and access is temporarily blocked. It
               is allowed max 50 requests per hour.
     "500":
-      description: Internal server error.
+      description: |-
+        Internal server error.
+
+        FIXME: a differenza di 503, 
+               questa risposta di solito non fa parte del contratto ;)
+               si può usare `default`
+      x-noqa: Risposta OAuth2
       content:
         application/json:
           schema:
@@ -361,7 +331,26 @@ components:
             error_description:
               The server is currently unable to handle the request due to
               maintenance or temporary overload.
+  parameters:
+    service_id:
+      in: query
+      name: service_id
+      required: false
+      schema:
+        type: string
+        format: uuid
+      description:
+        Identifier of the service (or class of services) as given in the
+        online OAS3 catalog of delegable services provided by the
+        authenticated RP. It must be a UUID v4 identifier.
+      example: 21905575-991a-43d5-bede-25f59ae93373
+
   schemas:
+    HTMLDocument:
+      type: string
+      description: HTML page with the Terms of Service
+    Problem:
+      $ref: "https://teamdigitale.github.io/openapi/v0.1.0/definitions.yaml#/components/schemas/Problem"
     Authorization:
       type: string
       example: DPoP Kz~8mXK1EalYznwH-LC-1fBAo.4Ljp~zsPE_NeO.gxU
@@ -369,37 +358,101 @@ components:
       type: string
       example:
         "eyJ0eXAiOiJkcG9wK2p3dCIsImFsZyI6IkVTMjU2IiwiandrIjp7Imt0eSI6IkVDIiwieCI6Imw4dEZyaHgtMzR0VjNoUklDUkRZOXpDa0RscEJoRjQyVVFVZldWQVdCRnMiLCJ5IjoiOVZFNGpmX09rX282NHpiVFRsY3VOSmFqSG10NnY5VERWclUwQ2R2R1JEQSIsImNydiI6IlAtMjU2In19.eyJqdGkiOiJlMWozVl9iS2ljOC1MQUVCIiwiaHRtIj      oiR0VUIiwiaHR1IjoiaHR0cHM6Ly9yZXNvdXJjZS5leGFtcGxlLm9yZy9wcm90ZWN0Z      WRyZXNvdXJjZSIsImlhdCI6MTU2MjI2MjYxOCwiYXRoIjoiZlVIeU8ycjJaM0RaNTNFc05yV0JiMHhXWG9hTnk1OUlpS0NBcWtzbVFFbyJ9.2oW9RP35yRqzhrtNP86L-Ey71E    OptxRimPPToA1plemAgR6pxHF8y6-yqyVnmcw6Fy1dqd-jfxSYoMxhAJpLjA"
+    DelegationId:
+      type: string
+      description: Identitier of this delegation
+      format: uuid4
+    Delegation:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - "https://attributes.eid.gov.it/fiscal_number"
+      description: |-
+        Each delegation is
+        identified by the parameter id and the related fiscal number of
+        delegating is given partially hidden for privacy reason.
+
+        FIXME: dobbiamo prevedere la possibilità che il codice fiscale
+        del delegante sia in chiaro?
+
+        FIXME: come uso il dato offuscato?
+      properties:
+        id:
+          $ref: '#/components/schemas/DelegationId'
+        "https://attributes.eid.gov.it/fiscal_number":
+          $ref: '#/components/schemas/TINObfuscated'
+
+    TIN: &TIN
+      type: string
+      pattern: ^TIN[A-Z]{2}-[A-Z0-9]+$
+      description:
+        Contains the fiscal number of the
+        delegate holder of the delegation preceded by the prefix TIN
+        followed by the country code (ISO 3166-1) as required by ETSI EN
+        319-412-1.
+      example: "TINIT-RSSMRA70A0H501I"
+    TINObfuscated:
+      <<: *TIN
+      pattern: ^TIN[A-Z]{2}-[A-Z0-9]{5}.+[A-Z]$
+      example: "TINIT-RSSMR**********I"
     Delegations:
       type: object
-      description:
-        "JSON Object containing the delegation list. Each delegation is
-        identified by the parameter id and the related fiscal number of
-        delegating is given partially hidden for privacy reason"
+      description: |-
+        JSON Object containing the delegation list.
+
+        FIXME: valutare delle properties di contorno 
+               utili anche alla paginazione (count, limit, next, ...)
       properties:
         items:
           type: array
+          minItems: 1
           items:
-            minItems: 1
-            type: object
-            properties:
-              id:
-                type: string
-                description: Identitier of this delegation
-              https://attributes.eid.gov.it/fiscal_number:
-                type: string
-                description:
-                  Fiscal number of the delegating subject partially hidden
-                  preceded by the prefix TINIT-
-            required:
-              - id
-              - https://attributes.eid.gov.it/fiscal_number
-    DelegationAttribute:
+            $ref: '#/components/schemas/Delegation'
+    UnixTimestamp: &UnixTimestamp
+      type: integer
+      format: int64
+      minimum: 0
+      exclusiveMinimum: true
+      description: UNIX timestamp
+      example: 1650573248
+
+    APIVersions:
       type: object
       description:
-        'JWT Object representing the "delegation-attribute", containing the
+        "JSON Object containing the list of all available versions of
+        this API."
+      properties:
+        versions:
+          type: array
+          minItems: 1
+          items:
+            type: object
+            required:
+              - iat
+              - version
+            properties:
+              iat:
+                <<: *UnixTimestamp
+                description:
+                  UNIX timestamp of when this version was released
+              version:
+                type: string
+                description: |-
+                  Version identifier of API given in the format
+                  'v<MAJOR.MINOR.PATCH>'
+
+                  FIXME: pubblicare la patch release può creare
+                          problemi di interoperabilità. Le PATCH
+                          non devono impattare sull'interfaccia.
+
+    DelegationAttribute:
+      type: object
+      description: |-
+        JWT Object representing the "delegation-attribute", containing the
         identifying information about the delegated and delegating subjects and
         the characteristics of the delegation. It is transmitted in the standard
-        format (as a base64_url encoded string)'
+        format (as a base64_url encoded string)
       properties:
         header:
           type: object
@@ -436,44 +489,37 @@ components:
               description: Identifier of this token
               example: "2bcbb3b9-cb5b-4ff7-81b0-3da894dd8c62"
             iat:
-              type: integer
-              minimum: 0
-              exclusiveMinimum: true
+              <<: *UnixTimestamp
               description: UNIX timestamp of when this token was created
-              example: 1650575048
             iss:
               type: string
+              format: url
               description: Identifier of the entity which issued this token
               default: https://deleghedigitali.gov.it/
               example: "https://deleghedigitali.gov.it/"
             sub:
-              type: string
-              description:
-                Delegate User Identifier. Contains the fiscal number of the
-                delegate holder of the delegation preceded by the prefix TIN
-                followed by the country code (ISO 3166-1) as required by ETSI EN
-                319-412-1.
-              example: "TINIT-RSSMRA70A0H501I"
+              title: Delegate User Identifier. 
+              <<: *TIN
             id:
               type: string
-              description: Identitier of this delegation as defined in SGD
+              description: |-
+                Identitier of this delegation as defined in SGD
+                FIXME: c'è una sintasssi da rispettare?
               example: "1A00001AA21"
             given_name:
               type: string
-              description: First name of the delgating subject
+              description: |-
+                First name of the delgating subject
+
+                TODO: dev'essere maiuscolo? Stessa domanda per il cognome.
               example: "ALESSANDRO"
             family_name:
               type: string
               description: Last name of the delgating subject
               example: "BIANCHI"
             https://attributes.eid.gov.it/fiscal_number:
-              type: string
-              description:
-                Fiscal number  of the delgating subject preceded by the prefix
-                TIN followed by the country code (ISO 3166-1) as required by
-                ETSI EN 319-412-1. If it is not available, then birthdate is
-                required.
-              example: "TINIT-BNCLSN71H10H501B"
+              <<: *TIN
+              title: Delegator identifier
             birthdate:
               type: string
               description: Date of birth of delegating subject
@@ -485,32 +531,25 @@ components:
             phone_number:
               type: string
               description: mobile phone number of the delegating subject
+              pattern: ^\+[0-9]+
               example: "+391234567890"
             https://sgd.gov.it/delegation_iat:
-              type: integer
-              minimum: 0
-              exclusiveMinimum: true
+              <<: *UnixTimestamp
               description: UNIX timestamp of when the delegation is created
-              example: 1650573248
             https://sgd.gov.it/delegation_nbf:
-              type: integer
-              minimum: 0
-              exclusiveMinimum: true
+              <<: *UnixTimestamp
               description: UNIX timestamp of when the delegation is valid
-              example: 1650573248
             https://sgd.gov.it/delegation_exp:
-              type: integer
-              minimum: 0
-              exclusiveMinimum: true
+              <<: *UnixTimestamp
               description: UNIX timestamp of when the delegation is expired
-              example: 1650576848
             https://sgd.gov.it/delegation_los:
               type: array
-              description:
-                List of identifiers of services (or class of services) provided
+              description: |-
+                Service (or class of services) identifiers provided
                 by the authenticated RP and contained in the given delegation
               items:
                 type: string
+                format: uuid
                 description: Identifier of the service given as UUID v4
                 example: 18971e49-3c04-4e97-8344-02c01aeee936
               example:
@@ -534,6 +573,9 @@ components:
           description: Signature of this JWT
     Errors:
       type: object
+      required:
+        - error
+        - error_description
       properties:
         error:
           description: Error Code
@@ -542,12 +584,10 @@ components:
           description:
             Human-readable ASCII encoded text description of the error
           type: string
-      required:
-        - error
-        - error_description
 
   examples:
-    delegations_attributes:
+    DelegationAttributes:
+      summary: A JWS (expressed in expanded syntax.)
       value:
         header:
           alg: "RS256"
@@ -559,10 +599,10 @@ components:
           sub: "TINIT-RSSMRA70A0H501I"
           iat: 1650575048
           jti: "2bcbb3b9-cb5b-4ff7-81b0-3da894dd8c62"
-          given_name: "ALESSANDRO"
+          given_name: "ALESSANDRO"  # FIXME: il nome DEVE essere in maiuscolo?
           family_name: "BIANCHI"
-          https://attributes.eid.gov.it/fiscal_number: "TINIT-BNCLSN71H10H501B"
-          birthdate: "01/01/1980"
+          "https://attributes.eid.gov.it/fiscal_number": "TINIT-BNCLSN71H10H501B"
+          birthdate: "01/01/1980"  # FIXME: perché la data di nascita non è in rfc3339 ?
           email: "a.bianchi@email.com"
           phone_number: "+391234567890"
           https://sgd.gov.it/delegation_iat: 1650573248
@@ -570,16 +610,19 @@ components:
           https://sgd.gov.it/delegation_exp: 1650576848
           https://sgd.gov.it/delegation_los:
             - "18971e49-3c04-4e97-8344-02c01aeee936"
-            - "2fef181-0ae8-4c93-9daa-0cab2b5c0f7e"
-    delegations:
+            - "32fef181-0ae8-4c93-9daa-0cab2b5c0f7e"
+    Delegations:
+      summary: A list of Delegations
       value:
+        items:
           - id: 1A00001AA21
             https://attributes.eid.gov.it/fiscal_number: TINIT-RSSMR*********I
           - id: 1A00002AA21
             https://attributes.eid.gov.it/fiscal_number: TINIT-ABCXX*********Z
           - id: 1A00004AA21
             https://attributes.eid.gov.it/fiscal_number: TINIT-DEFYY*********W
-    delegations_services:
+    DelegationsServices:
+      summary: A list of services
       value:
           - id: 1A00001AA21
             https://attributes.eid.gov.it/fiscal_number: TINIT-RSSMR*********I
@@ -599,3 +642,9 @@ tags:
       #Riferimento al sito agid dove sono state pubblicate le Linee Guida Attribute Authority SPID
       url: https://www.agid.gov.it/...
     name: protected
+  - description: |-
+      Implementing Agid guidelines
+    name: guidelines
+  - description: |-
+      Provide documentation
+    name: documentation


### PR DESCRIPTION
## This PR

Cleanup:

- create #/components/schemas for all responses, included HTMLDocument
- /status returns problem+json
- fixed examples datatypes and strings
- operationIds do not reference http methods 
- all documentation operations are under `/docs/` path to better isolate public and private pages (e.g. you can even have different ratelimit policies based on URLs)
- DPoP header requirements is specified by `security:` we don't need to mention it as a parameter
- /delegations/{security} and /delegations have the same responses. We can probably have one operationId using a query parameter. If there are specific caching policies for that, these should be explicited
- Removed redundand information from schemes: use plurals instead of `list_`
- added some FIXME: points to be investigated on

cc: @peppelinux @fmarino-ipzs 